### PR TITLE
fix auth on both domain.tld and *.domain.tld for ovh

### DIFF
--- a/ovh/cleanup.py
+++ b/ovh/cleanup.py
@@ -62,7 +62,8 @@ result = client.get('/domain/zone/' + certbot_domain + '/record',
 
 if len(result) == 0:
     print('***ERROR: Existing _acme-challenge record not found, exiting')
-    exit(1)
+    exit(0) # due to possible multi-domain gotcha i'm unsure if we should
+            # exit with an error
 
 record_id = result[0]
 


### PR DESCRIPTION
Hello.

When adding both domain.tld and *.domain.tld to a certificate, the script is run 2 times, the TXT has the same key but a different value. Some people reported it in comments here : 
https://blog.blaisot.org/letsencrypt-wildcard-part2.html

This is an fix attempt by comparing the TXT value to CERTBOT_VALIDATION and not just the existence of the record.

As my cert was already renewed, i did not test it on the final version of the script in real life conditions (I just know DNS edits looks ok).

Could possibly still fail : the refresh command "result = client.post('/domain/zone/' + certbot_domain + '/refresh')" may be ignored if ovh decide it's not good to call it very fast, so maybe the wait loop might timeout, even if everything is in place to validate the domain.
